### PR TITLE
Add link to reference browser version in images

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,14 @@ contains saucectl with different versions of TestCafe.
 [Base image + Cypress](https://hub.docker.com/r/saucelabs/stt-cypress-mocha-node/tags)
 contains saucectl with different versions of Cypress.
 
+### Browser version supported
+
+- [Playwright](https://github.com/saucelabs/sauce-playwright-runner/releases/latest)
+- [Puppeteer](https://github.com/saucelabs/sauce-puppeteer-runner/releases/latest)
+- [TestCafe](https://github.com/saucelabs/sauce-testcafe-runner/releases/latest)
+- [Cypress](https://github.com/saucelabs/sauce-cypress-runner/releases/latest)
+
+
 ## Examples
 
 The examples here show how Pipeline testing can be used. Try them and find your own use cases. Every testrunner image comes with a preconfigured setup that allows you to focus on writing tests instead of tweaking with the configurations. Our initial testrunner flavors come either with Puppeteer or Playwright as an automation framework. They will start the browser for you and expose the `browser` object ([Puppeteer](https://pptr.dev/#?product=Puppeteer&version=v3.0.3&show=api-class-browser) / [Playwright](https://playwright.dev/#version=v1.0.1&path=docs%2Fcore-concepts.md&q=browser)) to the global scope for you to be accessible in the test:


### PR DESCRIPTION
### Description

This PR adds a link to the different image details containing framework and browser versions

### Motivation and Context

Add an easier way to access shipped version

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

### Checklist
- [x] I have read the [contributing](https://github.com/saucelabs/saucectl/blob/master/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
