### PR TITLE
Document sauce connect in cypress

### DIFF
--- a/.sauce/cypress.yml
+++ b/.sauce/cypress.yml
@@ -2,6 +2,11 @@ apiVersion: v1alpha
 kind: cypress
 sauce:
   region: us-west-1
+## Tunnel allows you to specify an existing sauce connect tunnel when running cypress inside the Sauce cloud.
+## This has no effect when running tests inside docker.
+#  tunnel:
+#    id: your_tunnel_id
+#    parent: parent_owner_of_tunnel # if applicable, specify the owner of the tunnel
   metadata:
     name: Testing Cypress Support
     tags:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -132,6 +132,11 @@ apiVersion: v1alpha
 kind: cypress
 sauce:
   region: us-west-1
+## Tunnel allows you to specify an existing sauce connect tunnel when running cypress inside the Sauce cloud.
+## This has no effect when running tests inside docker.
+#  tunnel:
+#    id: your_tunnel_id
+#    parent: parent_owner_of_tunnel # if applicable, specify the owner of the tunnel
   metadata:
     name: Testing Cypress Support
     tags:


### PR DESCRIPTION
# What?
Document sauce connect usage when running on the sauce cloud.

# Why?
Because it's missing.